### PR TITLE
Add time inputs for finer track filtering precision

### DIFF
--- a/nuyina_map.html
+++ b/nuyina_map.html
@@ -126,6 +126,27 @@
             margin-bottom: 10px;
         }
 
+        .date-time-input {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .time-input {
+            background: #333;
+            border: 1px solid #555;
+            border-radius: 4px;
+            color: #e0e0e0;
+            padding: 2px 6px;
+            font-family: monospace;
+            font-size: 12px;
+        }
+
+        .time-input:focus {
+            outline: none;
+            border-color: #4a9eff;
+        }
+
         #datetime-readout {
             font-family: monospace;
             font-size: 11px;
@@ -432,8 +453,16 @@
                     <input type="range" id="slider-end" class="time-slider" min="0" max="364" value="364" step="1">
                 </div>
                 <div id="date-range">
-                    <span id="start-date"></span>
-                    <span id="end-date"></span>
+                    <div class="date-time-input">
+                        <span id="start-date"></span>
+                        <input type="time" id="start-time-input" class="time-input" value="00:00" step="600" title="Start time (UTC)">
+                        <span style="color: #666;">UTC</span>
+                    </div>
+                    <div class="date-time-input">
+                        <input type="time" id="end-time-input" class="time-input" value="23:59" step="600" title="End time (UTC)">
+                        <span style="color: #666;">UTC</span>
+                        <span id="end-date"></span>
+                    </div>
                 </div>
             </div>
             <div id="info">
@@ -495,6 +524,8 @@
             totalPages: 0,
             startDateIndex: 0,
             endDateIndex: 0,
+            startTimeUTC: '00:00',  // HH:MM in UTC
+            endTimeUTC: '23:59',    // HH:MM in UTC
             vesselTrack: [],
             transform: {
                 scale: 1,
@@ -663,6 +694,15 @@
             const minutes = String(date.getUTCMinutes()).padStart(2, '0');
             const seconds = String(date.getUTCSeconds()).padStart(2, '0');
             return `${year}-${month}-${day} ${hours}:${minutes}:${seconds} UTC`;
+        }
+
+        // Get full datetime from date index and time string (HH:MM in UTC)
+        function getFullDateTime(dateIndex, timeUTC) {
+            const date = state.dates[dateIndex];
+            const [hours, minutes] = timeUTC.split(':').map(Number);
+            const fullDate = new Date(date);
+            fullDate.setUTCHours(hours, minutes, 0, 0);
+            return fullDate;
         }
 
         // Get image URL for a date
@@ -891,9 +931,10 @@
             let vesselLon = null;
 
             if (state.vesselTrack.length > 0) {
-                const startDate = state.dates[state.startDateIndex];
+                const startDateTime = getFullDateTime(state.startDateIndex, state.startTimeUTC);
+                const endDateTime = getFullDateTime(state.endDateIndex, state.endTimeUTC);
                 const relevantPoints = state.vesselTrack.filter(p =>
-                    p.datetime >= startDate && p.datetime <= endDate
+                    p.datetime >= startDateTime && p.datetime <= endDateTime
                 );
 
                 if (relevantPoints.length > 0) {
@@ -1060,12 +1101,12 @@
                 ctx.restore();
             }
 
-            // Draw vessel track for the selected date range
+            // Draw vessel track for the selected date/time range
             if (state.vesselTrack.length > 0) {
-                const startDate = state.dates[state.startDateIndex];
-                const endDate = state.dates[state.endDateIndex];
+                const startDateTime = getFullDateTime(state.startDateIndex, state.startTimeUTC);
+                const endDateTime = getFullDateTime(state.endDateIndex, state.endTimeUTC);
                 const relevantPoints = state.vesselTrack.filter(p =>
-                    p.datetime >= startDate && p.datetime <= endDate
+                    p.datetime >= startDateTime && p.datetime <= endDateTime
                 );
 
                 if (relevantPoints.length > 0) {
@@ -1141,9 +1182,15 @@
             document.getElementById('start-date').textContent = formatDate(state.dates[state.startDateIndex]);
             document.getElementById('end-date').textContent = formatDate(state.dates[state.endDateIndex]);
 
-            // Update datetime readout
-            document.getElementById('start-datetime').textContent = formatDateTime(state.dates[state.startDateIndex]);
-            document.getElementById('end-datetime').textContent = formatDateTime(state.dates[state.endDateIndex]);
+            // Sync time inputs with state
+            document.getElementById('start-time-input').value = state.startTimeUTC;
+            document.getElementById('end-time-input').value = state.endTimeUTC;
+
+            // Update datetime readout with full date+time
+            const startDateTime = getFullDateTime(state.startDateIndex, state.startTimeUTC);
+            const endDateTime = getFullDateTime(state.endDateIndex, state.endTimeUTC);
+            document.getElementById('start-datetime').textContent = formatDateTime(startDateTime);
+            document.getElementById('end-datetime').textContent = formatDateTime(endDateTime);
         }
 
         // Fit image to canvas
@@ -1342,6 +1389,24 @@
                 } else {
                     e.target.value = state.endDateIndex;
                 }
+            });
+
+            // Time inputs
+            const startTimeInput = document.getElementById('start-time-input');
+            const endTimeInput = document.getElementById('end-time-input');
+
+            startTimeInput.addEventListener('change', (e) => {
+                state.startTimeUTC = e.target.value;
+                updateSliderRange();
+                render();
+                updateExternalLinks();
+            });
+
+            endTimeInput.addEventListener('change', (e) => {
+                state.endTimeUTC = e.target.value;
+                updateSliderRange();
+                render();
+                updateExternalLinks();
             });
 
             // Range dragging


### PR DESCRIPTION
- Add time input fields (HH:MM UTC) alongside date slider
- Track filtering now uses full datetime (date + time)
- Time inputs have 10-minute step increments matching track data
- Start defaults to 00:00 UTC, end defaults to 23:59 UTC
- Datetime readout shows selected time in UTC