### PR TITLE
Remove time input sync that may interfere with spinner stepping

### DIFF
--- a/nuyina_map.html
+++ b/nuyina_map.html
@@ -1182,10 +1182,6 @@
             document.getElementById('start-date').textContent = formatDate(state.dates[state.startDateIndex]);
             document.getElementById('end-date').textContent = formatDate(state.dates[state.endDateIndex]);
 
-            // Sync time inputs with state
-            document.getElementById('start-time-input').value = state.startTimeUTC;
-            document.getElementById('end-time-input').value = state.endTimeUTC;
-
             // Update datetime readout with actual track boundaries
             const startDateTime = getFullDateTime(state.startDateIndex, state.startTimeUTC);
             const endDateTime = getFullDateTime(state.endDateIndex, state.endTimeUTC);


### PR DESCRIPTION
The sync was resetting time input values during the input event, potentially conflicting with the browser's native spinner behavior.